### PR TITLE
Add trim to ProcessWhisper to better match keyword

### DIFF
--- a/AutoInvite.lua
+++ b/AutoInvite.lua
@@ -33,7 +33,7 @@ function AutoInvite:ProcessWhisper(text, playerName)
 		return
 	end
 
-	if text == AutoInviteSettings.AutoInviteKeyword then
+	if text:gsub("^%s*(.-)%s*$", "%1") == AutoInviteSettings.AutoInviteKeyword then
 		InviteUnit(playerName)
 	end
 end


### PR DESCRIPTION
I noticed people complaining about "inv " (space included) wouldn't work, so I added the same trim method as used for saving the keyword to the ProcessWhisper method.